### PR TITLE
add detection of another cemu proc name

### DIFF
--- a/LinuxGrabber.cs
+++ b/LinuxGrabber.cs
@@ -86,7 +86,7 @@ class LinuxGrabber {
         string processName = null;
         Process[] processes = Process.GetProcesses();
         foreach (Process process in processes) {
-            if (process.ProcessName.ToLower() == "cemu" || process.ProcessName.ToLower() == "xapfish") {
+            if (process.ProcessName.ToLower() == "cemu" || process.ProcessName.ToLower() == "xapfish" || process.ProcessName.ToLower()  == ".cemu-wrapped") {
                 processName = Convert.ToString(process.ProcessName);
             }
         }


### PR DESCRIPTION
for some reason, on nixos, cemu doesnt get the process name cemu, it gets .cemu-wrapped so im just adding that to the list of scanned processes